### PR TITLE
dependencies automatically download now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],
+    install_requires=[
+        'colorama',
+        'termcolor'
+    ],
     python_requires='>=3.9',
 )


### PR DESCRIPTION
Colorama and termcolor are not default packages, so anyone trying to `pip install pythonmommy` out of the box will be met with dependency errors. It's a small QoL thing, but this PR fixes those errors.