### PR TITLE
Typo-fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run whatever python you would normally but add "-m python_mommy" after python~
 
 print("Hello, world"
 
-> python -m pythonmommy hello.py
+> python -m python_mommy hello.py
 
 File "/home/little_girl/hello.py", line 1
     print("Hello, world"
@@ -39,12 +39,12 @@ mommy knows her little girl can do better~ ❤️
 You can alias mommy directly to python if you want, 
 
 ```text
-> alias python="python -m pythonmommy"
+> alias python="python -m python_mommy"
 ```
 
 # Configuration
 
-if you don't use standart interpreter, you can set it with environment variable `PYTHON_MOMMYS_INTERPRETER`. default is "python/python3/py", and `/` symbol separates different interpreters that mommy will try to find, from first to last.
+if you don't use standard interpreter, you can set it with environment variable `PYTHON_MOMMYS_INTERPRETER`. default is "python/python3/py", and `/` symbol separates different interpreters that mommy will try to find, from first to last.
 prepend `\` before `/` to escape it, for example `\/home\/user\/.local\/bin\/python/python/python3`
 
 Mommy will read the following environment variables to make her messages better for you~ ❤️


### PR DESCRIPTION
I noticed a few typos in README.md:
1. When installed from pip, the module name is `python_mommy` instead of `pythonmommy` so I fixed the references in `README.md`
2. Minor typo with 'standard' under [Configuration](https://github.com/Def-Try/python-mommy?tab=readme-ov-file#configuration) that I had to fix.